### PR TITLE
Friend request fixes

### DIFF
--- a/src/components/ConnectBox.js
+++ b/src/components/ConnectBox.js
@@ -93,7 +93,7 @@ export default class ConnectBox extends React.Component {
       }
     };
     BaseRequester.post(route, params).then((response) => {
-      this.props.onConnect();
+      this.props.onConnect(this.props.connection.id);
       onSuccess && onSuccess(response);
     }).catch((error) => {
       console.error(error);

--- a/src/components/FriendRequestModal.js
+++ b/src/components/FriendRequestModal.js
@@ -48,6 +48,27 @@ export default class FriendRequestModal extends React.Component {
     Animations.fade(this.state.helpAnimationValue, toValue = 1).start();
   }
 
+  /**
+   * See description in `resetAnimatedValue`.
+   */
+  componentWillReceiveProps(nextProps) {
+    if (this.props != nextProps) {
+      this.resetAnimatedValue();
+    }
+  }
+
+  /**
+   * Need to call this whenever the props are changed because it means that
+   * a friend request has been removed from the state container in ConnectScreen
+   * and by the nature of React, it tries to reuse this modal component and
+   * supply it with new props. Thus, when the old component is faded out (opacity
+   * is faded to 0), the new props are passed in but the entire modal becomes
+   * invisible. Must call this in componentWillReceiveProps to prevent this.
+   */
+  resetAnimatedValue() {
+    this.setState({ helpAnimationValue: new Animated.Value(1) });
+  }
+
   closeModal() {
     Animations.fade(this.state.helpAnimationValue).start(() => {
       this.props.onClose();
@@ -101,8 +122,8 @@ export default class FriendRequestModal extends React.Component {
       },
     };
     BaseRequester.patch(route, params).then((response) => {
-      this.closeModal();
       onSuccess && onSuccess();
+      this.closeModal();
     }).catch((error) => {
       console.error(error);
       onError && onError(error);

--- a/src/helpers/requesters/BaseRequester.js
+++ b/src/helpers/requesters/BaseRequester.js
@@ -12,36 +12,36 @@ class BaseRequester {
   /**
    * GET request on endpoint.
    */
-  static get(endpoint) {
+  static get(endpoint, urlParams) {
     return this._request(
-      'GET', endpoint, {}
+      'GET', endpoint, {}, urlParams
     );
   }
 
   /**
    * POST request on endpoint.
    */
-  static async post(endpoint, params) {
+  static async post(endpoint, params, urlParams) {
     return this._request(
-      'POST', endpoint, params
+      'POST', endpoint, params, urlParams
     );
   }
 
   /**
    * PATCH request on endpoint.
    */
-  static patch(endpoint, params) {
+  static patch(endpoint, params, urlParams) {
     return this._request(
-      'PATCH', endpoint, params
+      'PATCH', endpoint, params, urlParams
     );
   }
 
   /**
    * DELETE request on endpoint.
    */
-  static destroy(endpoint) {
+  static destroy(endpoint, urlParams) {
     return this._request(
-      'DELETE', endpoint, {}
+      'DELETE', endpoint, {}, urlParams
     );
   }
 
@@ -49,7 +49,7 @@ class BaseRequester {
    * Internal method to process all requests, wraps
    * fetch.
    */
-  static async _request(method, endpoint, params) {
+  static async _request(method, endpoint, params, urlParams) {
     const headers = this._getHeaders();
 
     let payload = {
@@ -60,6 +60,8 @@ class BaseRequester {
     if (method != 'GET') {
       payload.body = JSON.stringify(params);
     }
+
+    endpoint = _encodeUrlParams(endpoint, urlParams);
 
     return fetch(endpoint, payload).then((response) => {
       if (!response.ok) { throw response; }
@@ -85,6 +87,19 @@ class BaseRequester {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
     };
+  }
+
+  /**
+   * Encode any URL params for request and return the new
+   * query URL.
+   */
+  static _encodeUrlParams(endpoint, urlParams) {
+    if (!urlParams) return endpoint;
+    let esc = encodeURIComponent;
+    let query = Object.keys(urlParams)
+      .map(k => esc(k) + '=' + esc(urlParams[k]))
+      .join('&');
+    return endpoint + '?' + query;
   }
 
 }

--- a/src/screens/ConnectScreen.js
+++ b/src/screens/ConnectScreen.js
@@ -145,10 +145,8 @@ export default class ConnectScreen extends React.Component {
    */
   closeFriendRequestModal(i) {
     return () => {
-      const newFriendRequests = update(this.state.friendRequests, {
-        $apply: (reqs) => {return reqs.splice(i, 1)},
-      });
-      this.setState({ friendRequests: newFriendRequests });
+      this.state.friendRequests.splice(i, 1);
+      this.setState({ friendRequests: this.state.friendRequests });
     };
   }
 

--- a/src/screens/ConnectScreen.js
+++ b/src/screens/ConnectScreen.js
@@ -232,8 +232,6 @@ export default class ConnectScreen extends React.Component {
    * so can render instantly that they are now friends.
    */
   onConnectRequest(id) {
-    // this.state.activeConnection.sent_friend_request = true;
-    // this.setState({ activeConnection: this.state.activeConnection });
     /* Set veteran sent friend request state */
     let veteran = this.getVeteran(id);
     veteran.sent_friend_request = true;

--- a/src/screens/ConnectScreen.js
+++ b/src/screens/ConnectScreen.js
@@ -47,6 +47,8 @@ export default class ConnectScreen extends React.Component {
       friendRequests: [],
     }
 
+    this.veteransMapping = {};
+
     this.onRegionChange = this.onRegionChange.bind(this);
     this.onConnectRequest = this.onConnectRequest.bind(this);
     this.closeHelpModal = this.closeHelpModal.bind(this);
@@ -97,6 +99,7 @@ export default class ConnectScreen extends React.Component {
     const route = APIRoutes.veteransPath();
     BaseRequester.get(route).then((response) => {
       this.setState({ veterans: response });
+      this.veteransMapping = this.buildVeteransMapping();
     }).catch((error) => {
       console.error(error);
     });
@@ -126,6 +129,24 @@ export default class ConnectScreen extends React.Component {
     }).catch((error) => {
       console.error(error);
     });
+  }
+
+  /**
+   * Builds a map between veteran IDs and veteran objects for fast state updates
+   */
+  buildVeteransMapping() {
+    let mapping = {};
+    this.state.veterans.forEach((veteran) => {
+      mapping[veteran.id] = veteran;
+    });
+    return mapping;
+  }
+
+  /**
+   * Get's veteran object with corresponding veteran ID
+   */
+  getVeteran(id) {
+    return this.veteransMapping[id];
   }
 
   openHelpModal() {
@@ -204,12 +225,28 @@ export default class ConnectScreen extends React.Component {
    * Called when the ConnectBox "CONNECT" button is pressed by
    * this user, indicating a friend request sent to the other
    * user.
-   * FIXME (Ken): FIX THIS as bugged in certain situations
-   * See how solved in HomeScreen->ProfileCard
+   * FIXME (Ken): Maybe also include whether user has recv FR from this user
+   * so can render instantly that they are now friends.
    */
-  onConnectRequest() {
-    this.state.activeConnection.sent_friend_request = true;
-    this.setState({ activeConnection: this.state.activeConnection });
+  onConnectRequest(id) {
+    // this.state.activeConnection.sent_friend_request = true;
+    // this.setState({ activeConnection: this.state.activeConnection });
+    /* Set veteran sent friend request state */
+    let veteran = this.getVeteran(id);
+    veteran.sent_friend_request = true;
+    this.setState({ veterans: this.state.veterans });
+
+    /* Remove any existing friend requests from that user */
+    let removeIndex = null;
+    this.state.friendRequests.forEach((req, i) => {
+      if (req.id === id) {
+        removeIndex = i;
+      }
+    });
+    if (removeIndex != null) {
+      this.state.friendRequests.splice(removeIndex, 1);
+      this.setState({ friendRequests: this.state.friendRequests });
+    }
   }
 
   /**

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -84,7 +84,7 @@ export default class ProfileScreen extends React.Component {
       },
     };
     BaseRequester.post(route, params).then((response) => {
-      navParams.onConnect();
+      navParams.onConnect(navParams.id);
       this.setState({ sentConnectRequest: true });
       onSuccess && onSuccess(response);
     }).catch((error) => {


### PR DESCRIPTION
Fixes #34 

Fixes another issue where if you access a veterans profile through a friend request popup and try to connect through that, it shows a setState error. Now we cache a mapping between veteran id and its index in the state array to update veterans quickly.